### PR TITLE
Fixed vehicle menu and flip car

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -82,15 +82,7 @@ local function SetupVehicleMenu()
         menu = 'vehiclemenu'
     }
 
-    local vehicleitems = {{
-        id = 'vehicle-flip',
-        label = Lang:t("options.flip"),
-        icon = 'car-burst',
-        onSelect = function()
-            TriggerEvent('radialmenu:flipVehicle')
-            lib.hideRadial()
-        end,
-    }}
+    local vehicleitems = {}
 
     vehicleitems[#vehicleitems+1] = convert(Config.VehicleDoors)
     if Config.EnableExtraMenu then vehicleitems[#vehicleitems+1] = convert(Config.VehicleExtras) end
@@ -103,7 +95,24 @@ local function SetupVehicleMenu()
         id = 'vehiclemenu',
         items = vehicleitems
     })
-    lib.addRadialItem(VehicleMenu)
+
+    CreateThread(function()
+        local isMenuAdded = false
+
+        while true do
+            Wait(500)
+
+            local newIsPedInVehicle = GetVehiclePedIsIn(cache.ped, false)
+
+            if newIsPedInVehicle ~= 0 and not isMenuAdded then
+                lib.addRadialItem(VehicleMenu)
+                isMenuAdded = true
+            elseif newIsPedInVehicle == 0 and isMenuAdded then
+                lib.removeRadialItem('vehicle')
+                isMenuAdded = false
+            end
+        end
+    end)
 end
 
 local function SetupRadialMenu()

--- a/config.lua
+++ b/config.lua
@@ -43,6 +43,14 @@ Config.MenuItems = {
                 icon = 'triangle-exclamation',
                 items = {
                     {
+                        id = 'flipvehicle',
+                        title = 'Flip Vehicle',
+                        icon = 'car',
+                        type = 'client',
+                        event = 'radialmenu:flipVehicle',
+                        shouldClose = true
+                    },
+                    {
                         id = 'handcuff',
                         title = 'Cuff',
                         icon = 'user-lock',


### PR DESCRIPTION
## Description

Changed it so that vehicle menu is only available while inside a vehicle and took the flip car option away from the vehicle menu and put into interactions so that you can unflip a vehicle

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My code fits the style guidelines.
- [ x ] My PR fits the contribution guidelines.
