### PR TITLE
fix: vehicle flip + vehicle steats

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -31,44 +31,42 @@ local function convert(tbl)
 end
 
 local function AddVehicleSeats()
-    CreateThread(function()
-        while true do
-            Wait(50)
-            if IsControlJustPressed(0, 23) and not cache.vehicle then
-                local vehicle = GetClosestVehicle()
-                if vehicle then
-                    local vehicleseats = {}
-                    local seatTable = {
-                        [1] = Lang:t("options.driver_seat"),
-                        [2] = Lang:t("options.passenger_seat"),
-                        [3] = Lang:t("options.rear_left_seat"),
-                        [4] = Lang:t("options.rear_right_seat"),
+    while true do
+        if IsPedInAnyVehicle(PlayerPedId(), true) and not cache.vehicle then
+            local coords = GetEntityCoords(PlayerPedId())
+            local vehicle = lib.getClosestVehicle(coords)
+            if vehicle then
+                local vehicleseats = {}
+                local seatTable = {
+                    [1] = Lang:t("options.driver_seat"),
+                    [2] = Lang:t("options.passenger_seat"),
+                    [3] = Lang:t("options.rear_left_seat"),
+                    [4] = Lang:t("options.rear_right_seat"),
+                }
+                local AmountOfSeats = GetVehicleModelNumberOfSeats(GetEntityModel(vehicle))
+                for i = 1, AmountOfSeats do
+                    vehicleseats[#vehicleseats+1] = {
+                        id = 'vehicleseat'..i,
+                        label = seatTable[i] or Lang:t("options.other_seats"),
+                        icon = 'caret-up',
+                        onSelect = function()
+                            if cache.vehicle then
+                                TriggerEvent('radialmenu:client:ChangeSeat', i, seatTable[i] or Lang:t("options.other_seats"))
+                            else
+                                exports.qbx_core:Notify(Lang:t('error.not_in_vehicle'), 'error')
+                            end
+                            lib.hideRadial()
+                        end,
                     }
-
-                    local AmountOfSeats = GetVehicleModelNumberOfSeats(GetEntityModel(vehicle))
-                    for i = 1, AmountOfSeats do
-                        vehicleseats[#vehicleseats+1] = {
-                            id = 'vehicleseat'..i,
-                            label = seatTable[i] or Lang:t("options.other_seats"),
-                            icon = 'caret-up',
-                            onSelect = function()
-                                if cache.vehicle then
-                                    TriggerEvent('radialmenu:client:ChangeSeat', i, seatTable[i] or Lang:t("options.other_seats"))
-                                else
-                                    exports.qbx_core:Notify(Lang:t('error.not_in_vehicle'), 'error')
-                                end
-                                lib.hideRadial()
-                            end,
-                        }
-                    end
-                    lib.registerRadial({
-                        id = 'vehicleseatsmenu',
-                        items = vehicleseats
-                    })
                 end
+                lib.registerRadial({
+                    id = 'vehicleseatsmenu',
+                    items = vehicleseats
+                })
             end
         end
-    end)
+        Wait(1000)
+    end
 end
 
 local function SetupVehicleMenu()
@@ -93,7 +91,7 @@ local function SetupVehicleMenu()
     if Config.EnableExtraMenu then vehicleitems[#vehicleitems+1] = convert(Config.VehicleExtras) end
 
     if Config.VehicleSeats then
-        AddVehicleSeats()
+        CreateThread(AddVehicleSeats)
         vehicleitems[#vehicleitems+1] = Config.VehicleSeats
     end
     lib.registerRadial({

--- a/client/main.lua
+++ b/client/main.lua
@@ -261,7 +261,10 @@ end)
 
 RegisterNetEvent('radialmenu:flipVehicle', function()
     if cache.vehicle then return end
-    lib.progressBar({
+    local coords = GetEntityCoords(PlayerPedId())
+    local vehicle = lib.getClosestVehicle(coords)
+    if not vehicle then return exports.qbx_core:Notify(Lang:t("error.no_vehicle_nearby"), 'error') end
+    if lib.progressBar({
         label = Lang:t("progress.flipping_car"),
         duration = Config.Fliptime,
         useWhileDead = false,
@@ -269,25 +272,22 @@ RegisterNetEvent('radialmenu:flipVehicle', function()
         disable = {
             move = true,
             car = true,
-            mouse = true,
+            mouse = false,
             combat = true
         },
         anim = {
             dict = 'mini@repair',
             clip = 'fixing_a_ped'
         },
-    }, {}, {}, {}, function() -- Done
-        local vehicle, distance = lib.getClosestVehicle()
-        if distance <= 15 then
-            SetVehicleOnGroundProperly(vehicle)
-            exports.qbx_core:Notify(Lang:t("success.flipped_car"), 'success')
-        else
-            exports.qbx_core:Notify(Lang:t("error.no_vehicle_nearby"), 'error')
-        end
-    end, function() -- Cancel
+    })
+    then
+        SetVehicleOnGroundProperly(vehicle)
+        exports.qbx_core:Notify(Lang:t("success.flipped_car"), 'success')
+    else
         exports.qbx_core:Notify(Lang:t("error.cancel_task"), 'error')
-    end)
+    end
 end)
+
 AddEventHandler('onResourceStart', function(resource)
     if resource == GetCurrentResourceName() then
         if LocalPlayer.state.isLoggedIn then


### PR DESCRIPTION
## Description
This pull request change the  'radialmenu:flipVehicle' event.
You should merge it because it fix the problem when you try to flip a car.

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
