### PR TITLE
fix: disable radialmenu on death or leo/ems options

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,6 @@
-RegisterNetEvent('hospital:server:SetLaststandStatus', function(isDead)
-    TriggerClientEvent('radialmenu:client:deadradial', source, isDead)
+AddStateBagChangeHandler('qbx_medical:deathState', nil, function(bagName, _, value)
+    local playerId = GetPlayerFromStateBagName(bagName)
+    TriggerClientEvent('radialmenu:client:deadradial', playerId, value == 2 or value == 3)
 end)
 
 -- qb-amublancejob compatibility


### PR DESCRIPTION
## Description
Seems like manason broke it 4 months ago by getting rid of the events and no one really noticed it (except #47)
Took way too long to figure it out but better late than never?

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
