### PR TITLE
Fix double job menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -133,19 +133,17 @@ local function setupRadialMenu()
 
     if config.gangItems[QBX.PlayerData.gang.name] then
         lib.addRadialItem(convert({
-            id = 'ganginteractions',
+            id = 'gangInteractions',
             label = locale('general.gang_radial'),
             icon = 'skull-crossbones',
             items = config.gangItems[QBX.PlayerData.gang.name]
         }))
     end
 
-    if not config.jobItems[QBX.PlayerData.job.name] then return end
-
-	if not onduty then return end
+    if not config.jobItems[QBX.PlayerData.job.name] or not QBX.PlayerData.job.onduty then return end
 
     lib.addRadialItem(convert({
-        id = 'jobinteractions',
+        id = 'jobInteractions',
         label = locale('general.job_radial'),
         icon = 'briefcase',
         items = config.jobItems[QBX.PlayerData.job.name]
@@ -326,11 +324,10 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
 end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
-    lib.removeRadialItem('jobinteractions')
-	if not onduty then return end
+    lib.removeRadialItem('jobInteractions')
     if job.onduty and config.jobItems[job.name] then
         lib.addRadialItem(convert({
-            id = 'jobinteractions',
+            id = 'jobInteractions',
             label = locale('general.job_radial'),
             icon = 'briefcase',
             items = config.jobItems[job.name]

--- a/client/main.lua
+++ b/client/main.lua
@@ -140,8 +140,9 @@ local function setupRadialMenu()
         }))
     end
 
-    if not QBX.PlayerData.job.onduty then return end
     if not config.jobItems[QBX.PlayerData.job.name] then return end
+
+	if not onduty then return end
 
     lib.addRadialItem(convert({
         id = 'jobinteractions',
@@ -326,6 +327,7 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
     lib.removeRadialItem('jobinteractions')
+	if not onduty then return end
     if job.onduty and config.jobItems[job.name] then
         lib.addRadialItem(convert({
             id = 'jobinteractions',


### PR DESCRIPTION
## Description

Fixes two menus for the player's job showing while on duty and removes menu when not on duty



- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
