### PR TITLE
fix(client/main): prevent radial duplication

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -325,14 +325,6 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
     lib.removeRadialItem('jobInteractions')
-    if job.onduty and config.jobItems[job.name] then
-        lib.addRadialItem(convert({
-            id = 'jobInteractions',
-            label = locale('general.job_radial'),
-            icon = 'briefcase',
-            items = config.jobItems[job.name]
-        }))
-    end
 end)
 
 RegisterNetEvent('QBCore:Client:SetDuty', function(onDuty)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
A race condition can occur where setduty and OnJobUpdate happen at the same time causing the radial menu to get duplicated which ox_lib freaks out on. This fixes that and moves the job menu creation to only toggling for duty.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
