### PR TITLE
fix(client): Backwards keepOpen.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -44,7 +44,7 @@ local function convert(tbl)
         onSelect = tbl.onSelect or function()
             if action then action() end
         end,
-        keepOpen = not tbl.keepOpen or false
+        keepOpen = tbl.keepOpen
     }
 end
 


### PR DESCRIPTION
The current logic seems pretty backwards that you have to do 'keepOpen = true' on a radial option to actually close it on click? With this, if keepOpen is false or not defined, it'll default to close on click.

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
