### PR TITLE
Add support for qb-radialmenu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -351,6 +351,12 @@ RegisterNetEvent('QBCore:Client:OnGangUpdate', function(gang)
     end
 end)
 
+local function createQBExport(name. cb)
+    AddEventHandler(('__cfx_export_qb-radialmenu_%s'):format(name), function(setCB)
+        setCB(cb)
+    end)
+end
+
 local function addOption(data, id)
     data.id = data.id or id and id
     lib.addRadialItem(convert(data))
@@ -358,9 +364,11 @@ local function addOption(data, id)
 end
 
 exports('AddOption', addOption)
+createQBExport('AddOption', addOption)
 
 local function removeOption(id)
     lib.removeRadialItem(id)
 end
 
 exports('RemoveOption', removeOption)
+createQBExport('RemoveOption', removeOption)

--- a/client/main.lua
+++ b/client/main.lua
@@ -351,7 +351,7 @@ RegisterNetEvent('QBCore:Client:OnGangUpdate', function(gang)
     end
 end)
 
-local function createQBExport(name. cb)
+local function createQBExport(name, cb)
     AddEventHandler(('__cfx_export_qb-radialmenu_%s'):format(name), function(setCB)
         setCB(cb)
     end)


### PR DESCRIPTION
## Description
Uses an export handler for qb-radialmenu to add compatibility for this resource.

I know it's a simple PR but eh, who cares.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
