### PR TITLE
Update client/main.lua to setup correct radial menu items after job change

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -325,6 +325,7 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
     lib.removeRadialItem('jobInteractions')
+    setupRadialMenu()
 end)
 
 RegisterNetEvent('QBCore:Client:SetDuty', function(onDuty)


### PR DESCRIPTION
## Description

Looks like previous change ensured previous job menu items get removed when switching jobs, but never added the appropriate job items back in for the new job. This fixes state issues in both qbx_taxijob and qbx_towjob resources. Without this, when you switch to either jobs at city hall, you get blips but no radial menu items until you log off and back on again.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
