### PR TITLE
Fix: RadialMenu seat changing menu and add missing language options in en locale

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -451,7 +451,7 @@ return {
     vehicleSeats = {
         id = 'vehicleSeats',
         icon = 'chair',
-        title = 'Vehicle Seats',
+        label = 'Vehicle Seats',
         menu = 'vehicleSeatsMenu'
     },
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -6,6 +6,7 @@
       "extra_not_present": "Extra %s Is Not Present on This Vehicle",
       "not_driver": "You Are Not the Driver of the Vehicle",
       "vehicle_driving_fast": "This Vehicle Is Moving Too Fast",
+      "seat_occupied": "This seat is occupied.",
       "race_harness_on": "You Have a Race Harness On; You Can't Switch",
       "obj_not_found": "Could Not Create the Requested Object",
       "not_near_ambulance": "You Are Not Near an Ambulance",


### PR DESCRIPTION
### What does your pull request change?
This pull request addresses the issue with the **vehicle seat changing menu** in **qbx_radialmenu**. The original implementation relied on a loop that checked continuously for a vehicle, which was inefficient. The code has been refactored to remove the default loop, streamline the logic, and improve performance.

The updated code registers the seat change menu only when the player enters a vehicle and ensures that the correct seats are available based on the vehicle's configuration.

### Why should it be merged?
This refactor improves performance by eliminating the unnecessary loop that ran continuously. It also makes the vehicle seat changing menu more efficient by only triggering when the player is in a vehicle. Additionally, the code was reorganized to improve readability and maintainability.

### Does it fix an issue?
Yes, it resolves [Issue #49](https://github.com/Qbox-project/qbx_radialmenu/issues/49) regarding the **vehicle seat changing menu**.

### Changes:
- Replaced the previous loop-based system with event-based logic that triggers when the player enters a vehicle.
- Removed unnecessary `while true` loop, which was inefficient.
- Optimized code structure for better readability and performance.
- Added missing language options in the menu.

### Before:
The previous implementation continuously checked if the player was in a vehicle and was inefficient because it used a loop to detect this, even when the player wasn’t interacting with the vehicle.

### After:
The new implementation registers the vehicle seat menu only when the player is in a vehicle, making the system more efficient. It also ensures that the vehicle seat options are dynamically generated based on the number of seats available in the vehicle.

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
