### PR TITLE
feat: Added some really cool feature to the configs and add blips module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@ Radial Menu Used With qbx_Core :arrows_counterclockwise:
 
 **Supports FontAwesome Icons!**
 Get the name from [FontAwesome](https://fontawesome.com/v5.0/icons?d=gallery&p=2&s=brands,light,regular,solid&m=free) (v5) and use the icon's name in the config.lua for the icon (no `fa-` or `#` just the name like `arrow-right`)
+
+
+## Blip Usage
+
+## toggleBlip
+```lua
+exports.qbx_radialmenu:toggleBlip(category)
+```
+### Parameters
+- `category` (string): The unique category of the blip to toggle
+
+
+## registerToggleableBlip
+```lua
+exports.qbx_radialmenu:registerToggleableBlip(blipId, category)
+```
+### Parameters
+- `blipId` (number): The blip handle to register
+- `category` (string): The unique category of the blip
+
+### Example
+```lua
+local blipHandle<const> = AddBlipForCoord(0.0, 0.0, 0.0)
+exports.qbx_radialmenu:registerToggleableBlip(blipHandle, "shops")
+```

--- a/client/main.lua
+++ b/client/main.lua
@@ -55,8 +55,12 @@ local function convert(tbl)
     if tbl.items then
         local items = {}
         for _, v in pairs(tbl.items) do
-            items[#items + 1] = convert(v)
+            local converted<const> = convert(v)
+            if converted then
+                items[#items + 1] = converted
+            end
         end
+        if #items == 0 then return end
 
         lib.registerRadial({
             id = tbl.id .. 'Menu',
@@ -143,7 +147,10 @@ local function setupRadialMenu()
     setupVehicleMenu()
 
     for _, v in pairs(config.menuItems) do
-        lib.addRadialItem(convert(v))
+        local converted<const> = convert(v)
+        if converted then
+            lib.addRadialItem(converted)
+        end
     end
 
     if config.gangItems[QBX.PlayerData.gang.name] then

--- a/client/main.lua
+++ b/client/main.lua
@@ -113,7 +113,9 @@ function setupVehicleMenu(seat)
         menu = 'vehicleMenu'
     }
 
-    local vehicleItems = {{
+    local vehicleItems = {}
+    if vehicleFlipped then
+      vehicleItems[#vehicleItems + 1] = {
         id = 'vehicle-flip',
         label = locale('options.flip'),
         icon = 'car-burst',
@@ -121,11 +123,22 @@ function setupVehicleMenu(seat)
             TriggerEvent('radialmenu:flipVehicle')
             lib.hideRadial()
         end
-    }}
+      }
+    end
 
-    vehicleItems[#vehicleItems + 1] = convert(config.vehicleDoors)
+    if config.vehicleItems then
+        for i = 1, #config.vehicleItems do
+            vehicleItems[#vehicleItems + 1] = convert(config.vehicleItems[i])
+        end
+    end
 
+    if config.vehicleWindows then
     vehicleItems[#vehicleItems + 1] = convert(config.vehicleWindows)
+    end
+
+    if config.vehicleDoors then
+        vehicleItems[#vehicleItems + 1] = convert(config.vehicleDoors)
+    end
 
     if config.enableExtraMenu then
         vehicleItems[#vehicleItems + 1] = convert(config.vehicleExtras)

--- a/config/client.lua
+++ b/config/client.lua
@@ -25,13 +25,15 @@ return {
                     id = 'givenum',
                     icon = 'address-book',
                     label = 'Give Contact Details',
-                    event = 'qb-phone:client:GiveContactDetails'
+                    event = 'qb-phone:client:GiveContactDetails',
+                    nearByPlayerOnly = true
                 },
                 {
                     id = 'getintrunk',
                     icon = 'car',
                     label = 'Get In Trunk',
-                    event = 'qb-trunk:client:GetIn'
+                    event = 'qb-trunk:client:GetIn',
+                    outSideVehicleOnly = true
                 },
                 {
                     id = 'cornerselling',
@@ -61,6 +63,7 @@ return {
                             icon = 'car-side',
                             label = 'Take Out Vehicle',
                             event = 'police:client:SetPlayerOutVehicle',
+                            nearByVehicleOnly = true
                         },
                         {
                             id = 'stealPlayer',
@@ -377,6 +380,7 @@ return {
                 icon = 'eye-slash',
                 label = 'Show/Hide Meter',
                 event = 'qb-taxi:client:toggleMeter',
+                onVehicleOnly = true
             },
             {
                 id = 'togglemouse',

--- a/config/client.lua
+++ b/config/client.lua
@@ -4,6 +4,17 @@ return {
     enableExtraMenu = true,
     flipTime = 15000,
 
+    vehicleItems = {
+      {
+          id = 'quickgivevehkeys',
+          icon = 'key',
+          label = locale('options.quickgivekeys'),
+          serverEvent = 'qbx_vehiclekeys:server:quickgivekeys',
+          outSideVehicleOnly = true,
+          nearByPlayerOnly = true
+      },
+    },
+
     menuItems = {
         {
             id = 'citizen',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 
 description 'qbx_radialmenu'
 repository 'https://github.com/Qbox-project/qbx_radialmenu'
-version '0.1.0'
+version '0.3.0'
 ox_lib 'locale'
 
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -52,6 +52,7 @@
     "passenger_seat": "Passenger Seat",
     "other_seats": "Other Seat",
     "rear_left_seat": "Rear Left Seat",
-    "rear_right_seat": "Rear Right Seat"
+    "rear_right_seat": "Rear Right Seat",
+    "quickgivekeys": "Quick Give Keys"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -42,7 +42,9 @@
     "getintrunk_command_desc": "Enter the Trunk",
     "putintrunk_command_desc": "Put the Player in the Trunk",
     "gang_radial": "Gang",
-    "job_radial": "Job"
+    "job_radial": "Job",
+    "blip_shown": "Blip shown",
+    "blip_hidden": "Blip hidden"
   },
   "options": {
     "flip": "Flip the Vehicle",

--- a/server/main.lua
+++ b/server/main.lua
@@ -7,3 +7,11 @@ end)
 RegisterNetEvent('hospital:server:SetDeathStatus', function(isDead)
     TriggerClientEvent('radialmenu:client:deadradial', source, isDead)
 end)
+
+RegisterNetEvent('qbx_radialmenu:server:saveBlipPreferences', function(blipPreferences)
+    local playerData<const> = exports.qbx_core:GetPlayer(source)
+
+    if playerData then
+        playerData.Functions.SetMetaData("blipPreferences", blipPreferences)
+    end
+end)


### PR DESCRIPTION
## Description
fix(client): prevent adding nil items in radial menu conversion
feat(vehicle): add quick give keys option and flip vehicle menu item
eat(blips): add toggleable blip categories with persistence
docs(blips): add documentation for blip usage and API

## Checklist
- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
